### PR TITLE
WIP: Allow to append default mapping file

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -1,0 +1,27 @@
+name: Python unittest
+
+on: [push]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        # This is the version of the action for setting up Python, not the Python version.
+        uses: actions/setup-python@v4
+        with:
+          # Semantic version range syntax or exact version of a Python version
+          python-version: '3.11'
+          # Optional - x64 or x86 architecture, defaults to x64
+          architecture: 'x64'
+          cache: 'pip'
+      # You can test your matrix by printing the current Python version
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Execute unit tests
+        run: python -m unittest tests/*.py

--- a/enoceanmqtt/overlays/homeassistant/ha_communicator.py
+++ b/enoceanmqtt/overlays/homeassistant/ha_communicator.py
@@ -399,13 +399,14 @@ def custom_merge(mapping_dict: Dict[int, Any], extra_mapping_dict: Dict[int, Any
         for func, val_func in val_rorg.items():
             for type_, val_type in val_func.items():
                 if 'entities' in val_type:
-                    for operation, entities_list in val_type['entities'].items():
-                        if operation == 'add':
-                            mapping_copy[rorg][func][type_]['entities'] = mapping_copy[rorg][func][type_]['entities'] + entities_list
-                        elif operation == 'remove':
-                            to_remove = [(entity['component'], entity['name']) for entity in entities_list]
+                    for element in val_type['entities']:
+                        if 'state' not in element or element['state'] == 'present':
+                            element.pop('state', None)
+                            mapping_copy[rorg][func][type_]['entities'].append(element)
+                        elif element['state'] == 'absent':
                             mapping_copy[rorg][func][type_]['entities'] = list(
                                 filter(
-                                lambda entity: (entity['component'], entity['name']) not in to_remove, mapping_copy[rorg][func][type_]['entities'])
+                                    lambda entity: (entity['component'], entity['name']) != (element['component'], element['name']),
+                                    mapping_copy[rorg][func][type_]['entities'])
                             )
     return mapping_copy

--- a/enoceanmqtt/overlays/homeassistant/ha_communicator.py
+++ b/enoceanmqtt/overlays/homeassistant/ha_communicator.py
@@ -400,13 +400,25 @@ def custom_merge(mapping_dict: Dict[int, Any], extra_mapping_dict: Dict[int, Any
             for type_, val_type in val_func.items():
                 if 'entities' in val_type:
                     for element in val_type['entities']:
-                        if 'state' not in element or element['state'] == 'present':
-                            element.pop('state', None)
-                            mapping_copy[rorg][func][type_]['entities'].append(element)
-                        elif element['state'] == 'absent':
+                        if 'action' in element and element['action'] == 'remove':
                             mapping_copy[rorg][func][type_]['entities'] = list(
                                 filter(
-                                    lambda entity: (entity['component'], entity['name']) != (element['component'], element['name']),
+                                    lambda entity: (entity['component'],
+                                                    entity['name']) != (element['component'],
+                                                                        element['name']),
                                     mapping_copy[rorg][func][type_]['entities'])
                             )
+                        if 'action' not in element or element['action'] == 'add':
+                            element.pop('action', None)
+                            try:
+                                identical_entity = next(entity
+                                                        for entity in mapping_copy[rorg][func][type_]['entities']
+                                                        if (entity['component'],
+                                                            entity['name']) == (element['component'],
+                                                                                element['name'])
+                                                        )
+                                identical_entity.update(element)
+                            except StopIteration:
+                                mapping_copy[rorg][func][type_]['entities'].append(element)
+
     return mapping_copy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyyaml
 tinydb
+git+https://github.com/mak-gitdev/enocean.git
 git+https://github.com/embyt/enocean-mqtt.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pyyaml
+tinydb
+enocean
+paho-mqtt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pyyaml
 tinydb
-enocean
-paho-mqtt
+git+https://github.com/embyt/enocean-mqtt.git

--- a/tests/resources/extra_mapping.yaml
+++ b/tests/resources/extra_mapping.yaml
@@ -1,0 +1,20 @@
+0xD2:
+  0x01:
+    0x01:
+      entities:
+        - component: "switch"
+          name: "switch2"
+          config:
+            state_topic: "CMD4"
+            state_on: "100"
+            state_off: "0"
+            value_template: "{{ value_json.OV }}"
+            command_topic: "req"
+            payload_on: >
+              {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
+            payload_off: >
+              {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
+            device_class: outlet
+        - component: "button"
+          name: "query_status"
+          state: "absent"

--- a/tests/resources/extra_mapping.yaml
+++ b/tests/resources/extra_mapping.yaml
@@ -17,4 +17,4 @@
             device_class: outlet
         - component: "button"
           name: "query_status"
-          state: "absent"
+          action: "remove"

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -84,6 +84,20 @@ class MappingTestCase(unittest.TestCase):
         print(merged_mapping[0xD2][0x05][0x00]['entities'])
         self.assertTrue(entity_to_remove not in merged_mapping[0xD2][0x05][0x00]['entities'])  # add assertion here
 
+    def test_file_mapping(self):
+        mapping_path = Path(__file__).parent.parent / 'enoceanmqtt' / 'overlays' / 'homeassistant' / 'mapping.yaml'
+        extra_mapping_path = Path(__file__).parent / 'resources' / 'extra_mapping.yaml'
+        with open(mapping_path, 'r', encoding='utf-8') as mapping_file:
+            mapping = yaml.safe_load(mapping_file)
+        with open(extra_mapping_path, 'r', encoding='utf-8') as mapping_file:
+            extra_mapping = yaml.safe_load(mapping_file)
+        merged_mapping = custom_merge(mapping, extra_mapping)
+        print(mapping[0xD2][0x01][0x01]['entities'])
+        print(merged_mapping[0xD2][0x01][0x01]['entities'])
+        names = [entity['name'] for entity in merged_mapping[0xD2][0x01][0x01]['entities']]
+        self.assertTrue("switch2" in names)
+        self.assertTrue("query_status" not in names)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -40,7 +40,7 @@ class MappingTestCase(unittest.TestCase):
         entity_to_add = {'component': "cover",
                          'name': "cover2",
                          'config': {},
-                         'state': 'present'}
+                         'action': 'add'}
         extra_mapping = {
             0xD2: {
                 0x05: {
@@ -60,13 +60,40 @@ class MappingTestCase(unittest.TestCase):
         self.assertTrue(entity_to_add not in mapping[0xD2][0x05][0x00]['entities'])
         self.assertTrue('state' not in merged_mapping[0xD2][0x05][0x00]['entities'][-1])
 
+    def test_add_identical_mapping(self):
+        mapping_path = Path(__file__).parent.parent / 'enoceanmqtt' / 'overlays' / 'homeassistant' / 'mapping.yaml'
+        with open(mapping_path, 'r', encoding='utf-8') as mapping_file:
+            mapping = yaml.safe_load(mapping_file)
+        entity_to_add = {'component': "cover",
+                         'name': "cover",
+                         'added_key': 'added_value',
+                         'action': 'add'}
+        extra_mapping = {
+            0xD2: {
+                0x05: {
+                    0x00: {
+                        'entities':
+                            [
+                                entity_to_add,
+                            ]
+                    }
+                }
+            }
+        }
+        merged_mapping = custom_merge(mapping, extra_mapping)
+        print(mapping[0xD2][0x05][0x00]['entities'])
+        print(merged_mapping[0xD2][0x05][0x00]['entities'])
+        self.assertTrue((entity_to_add | mapping[0xD2][0x05][0x00]['entities'][0]) in merged_mapping[0xD2][0x05][0x00]['entities'])  # add assertion here
+        self.assertTrue(entity_to_add not in mapping[0xD2][0x05][0x00]['entities'])
+        self.assertTrue('action' not in merged_mapping[0xD2][0x05][0x00]['entities'][-1])
+
     def test_remove_mapping(self):
         mapping_path = Path(__file__).parent.parent / 'enoceanmqtt' / 'overlays' / 'homeassistant' / 'mapping.yaml'
         with open(mapping_path, 'r', encoding='utf-8') as mapping_file:
             mapping = yaml.safe_load(mapping_file)
         entity_to_remove = {'component': "cover",
                             'name': "cover",
-                            'state': 'absent'}
+                            'action': 'remove'}
         extra_mapping = {
             0xD2: {
                 0x05: {

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,65 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+from enoceanmqtt.overlays.homeassistant.ha_communicator import custom_merge
+
+
+class MappingTestCase(unittest.TestCase):
+
+    def test_add_mapping(self):
+        mapping_path = Path(__file__).parent.parent / 'enoceanmqtt' / 'overlays' / 'homeassistant' / 'mapping.yaml'
+        with open(mapping_path, 'r', encoding='utf-8') as mapping_file:
+            mapping = yaml.safe_load(mapping_file)
+        entity_to_add = {'component': "cover",
+                         'name': "cover2",
+                         'config': {}}
+        extra_mapping = {
+            0xD2: {
+                0x05: {
+                    0x00: {
+                        'entities': {
+                            'add':
+                            [
+                                entity_to_add,
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        merged_mapping = custom_merge(mapping, extra_mapping)
+        print(mapping[0xD2][0x05][0x00]['entities'])
+        print(merged_mapping[0xD2][0x05][0x00]['entities'])
+        self.assertTrue(entity_to_add in merged_mapping[0xD2][0x05][0x00]['entities'])  # add assertion here
+        self.assertTrue(entity_to_add not in mapping[0xD2][0x05][0x00]['entities'])
+
+    def test_remove_mapping(self):
+        mapping_path = Path(__file__).parent.parent / 'enoceanmqtt' / 'overlays' / 'homeassistant' / 'mapping.yaml'
+        with open(mapping_path, 'r', encoding='utf-8') as mapping_file:
+            mapping = yaml.safe_load(mapping_file)
+        entity_to_add = {'component': "cover",
+                         'name': "cover"}
+        extra_mapping = {
+            0xD2: {
+                0x05: {
+                    0x00: {
+                        'entities': {
+                            'remove':
+                                [
+                                    entity_to_add,
+                                ]
+                        }
+                    }
+                }
+            }
+        }
+        merged_mapping = custom_merge(mapping, extra_mapping)
+        print(mapping[0xD2][0x05][0x00]['entities'])
+        print(merged_mapping[0xD2][0x05][0x00]['entities'])
+        self.assertTrue(entity_to_add not in merged_mapping[0xD2][0x05][0x00]['entities'])  # add assertion here
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -19,12 +19,10 @@ class MappingTestCase(unittest.TestCase):
             0xD2: {
                 0x05: {
                     0x00: {
-                        'entities': {
-                            'add':
+                        'entities':
                             [
                                 entity_to_add,
                             ]
-                        }
                     }
                 }
             }
@@ -35,22 +33,22 @@ class MappingTestCase(unittest.TestCase):
         self.assertTrue(entity_to_add in merged_mapping[0xD2][0x05][0x00]['entities'])  # add assertion here
         self.assertTrue(entity_to_add not in mapping[0xD2][0x05][0x00]['entities'])
 
-    def test_remove_mapping(self):
+    def test_add_mapping_2(self):
         mapping_path = Path(__file__).parent.parent / 'enoceanmqtt' / 'overlays' / 'homeassistant' / 'mapping.yaml'
         with open(mapping_path, 'r', encoding='utf-8') as mapping_file:
             mapping = yaml.safe_load(mapping_file)
         entity_to_add = {'component': "cover",
-                         'name': "cover"}
+                         'name': "cover2",
+                         'config': {},
+                         'state': 'present'}
         extra_mapping = {
             0xD2: {
                 0x05: {
                     0x00: {
-                        'entities': {
-                            'remove':
-                                [
-                                    entity_to_add,
-                                ]
-                        }
+                        'entities':
+                            [
+                                entity_to_add,
+                            ]
                     }
                 }
             }
@@ -58,7 +56,33 @@ class MappingTestCase(unittest.TestCase):
         merged_mapping = custom_merge(mapping, extra_mapping)
         print(mapping[0xD2][0x05][0x00]['entities'])
         print(merged_mapping[0xD2][0x05][0x00]['entities'])
-        self.assertTrue(entity_to_add not in merged_mapping[0xD2][0x05][0x00]['entities'])  # add assertion here
+        self.assertTrue(entity_to_add in merged_mapping[0xD2][0x05][0x00]['entities'])  # add assertion here
+        self.assertTrue(entity_to_add not in mapping[0xD2][0x05][0x00]['entities'])
+        self.assertTrue('state' not in merged_mapping[0xD2][0x05][0x00]['entities'][-1])
+
+    def test_remove_mapping(self):
+        mapping_path = Path(__file__).parent.parent / 'enoceanmqtt' / 'overlays' / 'homeassistant' / 'mapping.yaml'
+        with open(mapping_path, 'r', encoding='utf-8') as mapping_file:
+            mapping = yaml.safe_load(mapping_file)
+        entity_to_remove = {'component': "cover",
+                            'name': "cover",
+                            'state': 'absent'}
+        extra_mapping = {
+            0xD2: {
+                0x05: {
+                    0x00: {
+                        'entities':
+                            [
+                                entity_to_remove,
+                            ]
+                    }
+                }
+            }
+        }
+        merged_mapping = custom_merge(mapping, extra_mapping)
+        print(mapping[0xD2][0x05][0x00]['entities'])
+        print(merged_mapping[0xD2][0x05][0x00]['entities'])
+        self.assertTrue(entity_to_remove not in merged_mapping[0xD2][0x05][0x00]['entities'])  # add assertion here
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR propose a method to let the user update default `mapping.yaml` without copying the entire file.

User must add an `extra_mapping_file` variable in the `enoceanmqtt.conf` file. 
This `extra_mapping_file` is a yaml file with similar structure than `mapping.yaml` file.
Removing an entity is done by adding `action: remove` in the entity description.