### PR TITLE
Add support for A5-14-09

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/mapping.yaml
+++ b/enoceanmqtt/overlays/homeassistant/mapping.yaml
@@ -2797,6 +2797,42 @@
                  value_template: >-
                    {% if value_json.CT == 0 %}OFF{% else %}ON{% endif %}
                  device_class: "window"
+      0x09:
+         device_config:
+            command: ""
+            channel: ""
+            log_learn: ""
+            direction: ""
+            answer: ""
+         entities:
+            - component: "sensor"
+              name: "v_raw"
+              config:
+                 state_topic: ""
+                 value_template: "{{ value_json.SVC }}"
+                 device_class: "voltage"
+                 unit_of_measurement: "V"
+                 enabled_by_default: "false"
+            - component: "sensor"
+              name: "voltage"
+              config:
+                 state_topic: ""
+                 value_template: "{{ value_json.SVC | round(2) }}"
+                 device_class: "voltage"
+                 unit_of_measurement: "V"
+            - component: binary_sensor
+              name: "state_2p"
+              config:
+                 state_topic: ""
+                 value_template: >-
+                   {% if value_json.CT == 0 %}OFF{% else %}ON{% endif %}
+                 device_class: "window"
+            - component: sensor
+              name: "state_3p"
+              config:
+                 state_topic: ""
+                 value_template: >-
+                   {% if value_json.CT == 0 %}off{% elif value_json.CT == 1 %}tilt{% elif value_json.CT == 3 %}open{% else %}reserved{% endif %}
       0x0A:
          device_config:
             command: ""


### PR DESCRIPTION
Hi @mak-gitdev,
This PR adds support for the A5-14-09 profile, which is very similar to the A5-14-0A profile but lacks a sensor for vibrations.
Please note that this PR depends on https://github.com/mak-gitdev/enocean/pull/2, as the EEP.xml file is sourced from the enocean python library.
Thank you!
