### PR TITLE
Change off to closed for A5-14-09 and A5-14-0A

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/mapping.yaml
+++ b/enoceanmqtt/overlays/homeassistant/mapping.yaml
@@ -3463,7 +3463,7 @@
               config:
                  state_topic: ""
                  value_template: >-
-                   {% if value_json.CT == 0 %}off{% elif value_json.CT == 1 %}tilt{% elif value_json.CT == 3 %}open{% else %}reserved{% endif %}
+                   {% if value_json.CT == 0 %}closed{% elif value_json.CT == 1 %}tilt{% elif value_json.CT == 3 %}open{% else %}reserved{% endif %}
       0x0A:
          device_config:
             command: ""
@@ -3499,7 +3499,7 @@
               config:
                  state_topic: ""
                  value_template: >-
-                   {% if value_json.CT == 0 %}off{% elif value_json.CT == 1 %}tilt{% elif value_json.CT == 3 %}open{% else %}reserved{% endif %}
+                   {% if value_json.CT == 0 %}closed{% elif value_json.CT == 1 %}tilt{% elif value_json.CT == 3 %}open{% else %}reserved{% endif %}
             - component: binary_sensor
               name: "vib"
               config:


### PR DESCRIPTION
Hello

Here's a small suggestion to name the "Closed" status of the window sensors according to the specification.

- [A5-14-09](http://tools.enocean-alliance.org/EEPViewer/profiles/A5/14/09/A5-14-09.pdf)
- [A5-14-0A](http://tools.enocean-alliance.org/EEPViewer/profiles/A5/14/0A/A5-14-0A.pdf)

Thank you.