### PR TITLE
Fix battery mapping for A5-20-06

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/mapping.yaml
+++ b/enoceanmqtt/overlays/homeassistant/mapping.yaml
@@ -4114,7 +4114,7 @@
               config:
                  state_topic: ""
                  value_template: >-
-                   {% if value_json.ES == 1 %}ON{% else %}OFF{% endif %}
+                   {% if value_json.ES == 1 %}OFF{% else %}ON{% endif %}
                  device_class: "battery"
             - component: "binary_sensor"
               name: "DWO"


### PR DESCRIPTION
Thank you for this great project. I successfully setup EnOcean TRV after noticing [here](https://github.com/mak-gitdev/HA_enoceanmqtt/discussions/74) that support for this device type was added. I have not yet wrapped my head around on how to set the setpoint temperature from Home Assistant, but I will surely make it in the end. :)

In the mean time I noticed that, the binary sensor logic should be swapped around.

Enocean:
ES 1 - Energy storage sufficiently charged
ES 0 - Energy storage low

![image](https://github.com/mak-gitdev/HA_enoceanmqtt/assets/422086/8c2151ea-a03e-4b19-87e0-6a1939c7dae3)
https://micropelt.atlassian.net/wiki/download/attachments/184221711/Micropelt_MVA009%20(EN)_DS_0523.pdf?api=v2

Homeassistant:
battery: on means low, off means normal (from https://www.home-assistant.io/integrations/binary_sensor/)