### PR TITLE
Fix for the new version of enocean-mqtt

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,6 @@ RUN apk add --no-cache git && \
     python3 -m pip install --upgrade pip && \
     pip3 install pyyaml==6.0.1 && \
     pip3 install tinydb==4.7.1 && \
-    pip3 install paho-mqtt==1.6.1 && \
     pip3 install git+https://github.com/mak-gitdev/enocean.git && \
     git clone -b master --single-branch --depth 1 https://github.com/embyt/enocean-mqtt.git && \
     cd enocean-mqtt && python3 setup.py develop && cd .. && \

--- a/enoceanmqtt/overlays/homeassistant/ha_communicator.py
+++ b/enoceanmqtt/overlays/homeassistant/ha_communicator.py
@@ -81,9 +81,9 @@ class HACommunicator(Communicator):
     #=============================================================================================
     # MQTT CLIENT
     #=============================================================================================
-    def _on_connect(self, mqtt_client, _userdata, _flags, return_code):
+    def _on_connect(self, mqtt_client, _userdata, _flags, reason_code, properties):
         '''callback for when the client receives a CONNACK response from the MQTT server.'''
-        if return_code == 0:
+        if reason_code == 0:
             logging.info("Succesfully connected to MQTT broker.")
             # listen to enocean send requests
             for cur_sensor in self.sensors:
@@ -140,8 +140,8 @@ class HACommunicator(Communicator):
                 self._first_mqtt_connect = False
         else:
             logging.error("Error connecting to MQTT broker: %s",
-                          self.CONNECTION_RETURN_CODE[return_code]
-                          if return_code < len(self.CONNECTION_RETURN_CODE) else return_code)
+                          self.CONNECTION_RETURN_CODE[reason_code]
+                          if reason_code < len(self.CONNECTION_RETURN_CODE) else reason_code)
 
     def _on_mqtt_message(self, _mqtt_client, _userdata, msg):
         '''the callback for when a PUBLISH message is received from the MQTT server.'''

--- a/standalone/install.sh
+++ b/standalone/install.sh
@@ -97,8 +97,6 @@ pip3 install --user --force-reinstall git+https://github.com/mak-gitdev/enocean.
 printf "\n==================================================\n"
 printf "Install enocean-mqtt\n\n"
 rm -rf enocean-mqtt
-# Quick Fix issue for issue mak-gitdev/HA_enoceanmqtt#122 (Force use of 1.6.1 as >=2.0.0 break enoceanmqtt)
-package_install paho-mqtt==1.6.1
 git clone -b master --single-branch --depth 1 https://github.com/embyt/enocean-mqtt.git
 cd enocean-mqtt && pip3 install --user -e . && cd ..
 


### PR DESCRIPTION
Since enocean-mqtt now requires paho-mqtt >= 2.0, these changes are needed.