### PR TITLE
include default configfile (enoceanmqtt.conf)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,10 @@ FROM python:3-alpine
 
 ARG BUILD_VERSION
 
+# Copy enoceanmqtt.conf.sample to container
+RUN mkdir /config
+COPY docker/enoceanmqtt.conf.sample /config/enoceanmqtt.conf
+
 # Create config volume
 VOLUME /config
 


### PR DESCRIPTION
This includes the default config-file so the docker is able to start when there is no config done yet.

This way you can run `sudo docker exec -it ha_enoceanmqtt_dev vi /config/enoceanmqtt.conf` to edit your configuration.

Without this PR, you MUST use a bind mount and import the configfile beforehand. In systems like cosmos-server, the preffered way is to NOT use bind mount but named volumes instead, hence an existing configfile is much easier.