### PR TITLE
fix: Fix EEP parsing for direction = ""

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/ha_communicator.py
+++ b/enoceanmqtt/overlays/homeassistant/ha_communicator.py
@@ -47,7 +47,7 @@ class HACommunicator(Communicator):
                 cur_sensor['command'] = devcfg.get('command')
                 cur_sensor['channel'] = devcfg.get('channel')
                 cur_sensor['log_learn'] = devcfg.get('log_learn')
-                cur_sensor['direction'] = devcfg.get('direction')
+                cur_sensor['direction'] = devcfg.get('direction') or None
                 cur_sensor['answer'] = devcfg.get('answer')
 
                 # Better to work with JSON in HA so force JSON usage


### PR DESCRIPTION
* in the HACommunicator, the sensor config overwrites the direction flag with "" from the mapping.yaml for some sensors
* in the enocean library, direction is expected to be 1, 2 or None to look up the corresponding profiles from the EEP.xml - setting it to "" causes the correct profile not to be found

This should fix #167 