### PR TITLE
Fix F6-02-01 RPS telegram decoding failure in HA overlay

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/ha_communicator.py
+++ b/enoceanmqtt/overlays/homeassistant/ha_communicator.py
@@ -44,11 +44,18 @@ class HACommunicator(Communicator):
                     pass
 
                 # Set EEP-related device configuration
-                cur_sensor['command'] = devcfg.get('command')
-                cur_sensor['channel'] = devcfg.get('channel')
-                cur_sensor['log_learn'] = devcfg.get('log_learn')
-                cur_sensor['direction'] = devcfg.get('direction')
-                cur_sensor['answer'] = devcfg.get('answer')
+                # Only set fields if they have non-empty values to avoid passing empty strings
+                # to the EnOcean library which expects None for unset parameters
+                if devcfg.get('command'):
+                    cur_sensor['command'] = devcfg.get('command')
+                if devcfg.get('channel'):
+                    cur_sensor['channel'] = devcfg.get('channel')
+                if devcfg.get('log_learn'):
+                    cur_sensor['log_learn'] = devcfg.get('log_learn')
+                if devcfg.get('direction'):
+                    cur_sensor['direction'] = devcfg.get('direction')
+                if devcfg.get('answer'):
+                    cur_sensor['answer'] = devcfg.get('answer')
 
                 # Better to work with JSON in HA so force JSON usage
                 # Also force publish_rssi, publish_date and persistent


### PR DESCRIPTION
## Summary
Fixes F6-02-01 RPS wall switches that fail to decode when HA overlay is enabled

## Problem
When the HA overlay is enabled, F6 (RPS) devices like the PTM210 wall switch produce "message not interpretable" errors and fail to publish MQTT messages, despite having correct mappings in mapping.yaml.

## Root Cause
The HA overlay unconditionally sets device configuration fields from mapping.yaml, even when those fields contain empty strings. For F6-02-01, all fields (command, channel, direction, etc.) are set to `""`.

The EnOcean library's `parse_eep()` method treats `direction=""` as an invalid parameter and fails to parse, while `direction=None` correctly means "no direction specified."

## Solution
Modified `ha_communicator.py` lines 46-58 to only set configuration fields if they have non-empty values. This ensures the EnOcean library receives `None` for unset parameters instead of empty strings.

## Testing
- ✅ PTM210 DB (F6-02-01) wall switch now decodes and publishes to MQTT
- ✅ ubiwizz relay (D2-01-01) still works correctly (backwards compatible)
- ✅ No "message not interpretable" errors
- ✅ MQTT messages include all expected fields (R1, EB, R2, SA, T21, NU)

## Files Changed
- `enoceanmqtt/overlays/homeassistant/ha_communicator.py`